### PR TITLE
fix: remove 'Test minitwit' step from CI/CD workflow

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -54,7 +54,6 @@ jobs:
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/flagtoolimage:flagtoolbuildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/flagtoolimage:flagtoolbuildcache,mode=max
 
-# Removed the Test minitwit step as per the issue report.
 
       - name: Configure SSH
         run: |

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -54,19 +54,7 @@ jobs:
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/flagtoolimage:flagtoolbuildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/flagtoolimage:flagtoolbuildcache,mode=max
 
-      - name: Test minitwit
-        run: |
-          docker build -t $DOCKER_USERNAME/minitwittestimage -f ./images/Dockerfile.test .
-          yes 2>/dev/null | docker compose -f remote_files/compose.yml up -d
-          docker run --rm --network=minitwit_main \
-          --env DB_USER=${DB_USER} --env DB_PWD=${DB_PWD} \
-          $DOCKER_USERNAME/minitwittestimage
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DB_USER: "test"
-          DB_PWD: "test"
-          APP_ENV: "test"
-
+# Removed the Test minitwit step as per the issue report.
 
       - name: Configure SSH
         run: |


### PR DESCRIPTION
This pull request makes a targeted change to the `.github/workflows/continuous-deployment.yml` file by removing a testing step for the `minitwit` service. The change aims to streamline the workflow based on an issue report.

**Workflow simplification:**

* Removed the "Test minitwit" step, which included building a Docker test image, setting up a test environment with `docker compose`, and running tests within the `minitwit_main` network. This step was removed following an issue report. (`[.github/workflows/continuous-deployment.ymlL57-R57](diffhunk://#diff-af36bb0ba98217223305c14372a4e893c25a61dcfa63a78b32eb3f37c6cd1285L57-R57)`)